### PR TITLE
fix: [PLG-2555] Rename the binary and the command name from `harness-cli` to `harness`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,5 +29,5 @@ jobs:
           goarch: ${{ matrix.goarch }}
           goversion: 1.19
           project_path: "."
-          binary_name: "harness-cli"
+          binary_name: "harness"
           ldflags: ${{ format('-X "main.Version={0}"', github.ref_name) }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .idea/
-harness-cli
-./harness-cli
 harness-upgrade
 .temp.data
 .secrets.json
+harness

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module harness-cli
+module harness
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 		}),
 	}
 	app := &cli.App{
-		Name:                 "harness-cli",
+		Name:                 "harness",
 		Version:              Version,
 		Usage:                "Setup Harness CD & GitOps in a few commands.",
 		EnableBashCompletion: true,

--- a/release.go
+++ b/release.go
@@ -87,7 +87,7 @@ func printUpgradeMessage(from string, to string) {
 	green := color.New(color.FgGreen).SprintFunc()
 	red := color.New(color.FgHiRed).SprintFunc()
 	yellow := color.New(color.FgYellow).SprintFunc()
-	fmt.Printf("[%s] A new release of harness-cli is available: %s → %s\n", blue("notice"), red(from), green(to))
+	fmt.Printf("[%s] A new release of harness cli is available: %s → %s\n", blue("notice"), red(from), green(to))
 	fmt.Printf("%s\n", yellow("https://github.com/harness/harness-cli/releases/tag/"+to))
-	fmt.Printf("To update, run: %s\n", green("harness-cli update"))
+	fmt.Printf("To update, run: %s\n", green("harness update"))
 }

--- a/update.go
+++ b/update.go
@@ -87,10 +87,10 @@ func readTar(body io.ReadCloser, dest string) error {
 		if err != nil {
 			return err
 		}
-		if header.Typeflag == tar.TypeReg && header.Name == "harness-cli" {
+		if header.Typeflag == tar.TypeReg && header.Name == "harness" {
 			execFile := path.Join(dest, header.Name)
 			green := color.New(color.FgGreen).SprintFunc()
-			fmt.Printf("Extracting harness-cli to - %s\n", green(execFile))
+			fmt.Printf("Extracting harness cli to - %s\n", green(execFile))
 			outFile, err := os.Create(execFile)
 			if err != nil {
 				return err

--- a/workflows/release.yaml
+++ b/workflows/release.yaml
@@ -29,5 +29,5 @@ jobs:
           goarch: ${{ matrix.goarch }}
           goversion: 1.19
           project_path: "."
-          binary_name: "harness-cli"
+          binary_name: "harness"
           ldflags: ${{ format('-X "main.Version={0}"', github.ref_name) }}


### PR DESCRIPTION
Renamed the binary and the command name from `harness-cli` to `harness`