### PR TITLE
[fix]: [PLG-2588]: not throwing log.Error() when respnse is NotFoundException(code=400) from ng-manager

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,7 +92,7 @@ func handleResp(req *http.Request) (respBodyObj ResponseBody, err error) {
 		log.Fatalln("There was error while parsing the response from server. Exiting...", err)
 	}
 	if resp.StatusCode != 200 {
-		if resp.StatusCode == 400 {
+		if resp.StatusCode >= 400 || resp.StatusCode < 500 {
 			println(respBodyObj.Message)
 		} else {
 			if len(respBodyObj.Message) > 0 {

--- a/client.go
+++ b/client.go
@@ -92,10 +92,14 @@ func handleResp(req *http.Request) (respBodyObj ResponseBody, err error) {
 		log.Fatalln("There was error while parsing the response from server. Exiting...", err)
 	}
 	if resp.StatusCode != 200 {
-		if len(respBodyObj.Message) > 0 {
-			log.Error(respBodyObj.Message)
-		} else if len(respBodyObj.Messages) > 0 && len(respBodyObj.Messages[0].Message) > 0 {
-			log.Error(respBodyObj.Messages[0].Message)
+		if resp.StatusCode == 400 {
+			println(respBodyObj.Message)
+		} else {
+			if len(respBodyObj.Message) > 0 {
+				log.Error(respBodyObj.Message)
+			} else if len(respBodyObj.Messages) > 0 && len(respBodyObj.Messages[0].Message) > 0 {
+				log.Error(respBodyObj.Messages[0].Message)
+			}
 		}
 		return respBodyObj, errors.New("received non 200 response code. The response code was " + strconv.Itoa(resp.StatusCode))
 	}


### PR DESCRIPTION
not throwing log.Error() when respnse is NotFoundException(code=400) from ng-manager

Old CLI Output:
<img width="1481" alt="Screenshot 2023-07-20 at 3 36 56 AM" src="https://github.com/harness/harness-cli/assets/90614549/789a6d8a-b463-483e-9ae6-5980c4850fa0">

New CLI Output:
<img width="1548" alt="Screenshot 2023-07-20 at 3 39 25 AM" src="https://github.com/harness/harness-cli/assets/90614549/a075fe3a-7485-48a2-9baf-bbec65b396f7">

