### PR TITLE
feat: [PLG-2611] Add flags to support Google Cloud Functions infrastructure apply from CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ harness-upgrade
 .temp.data
 .secrets.json
 harness
+harnesscd-example-apps

--- a/connector.go
+++ b/connector.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
@@ -77,10 +76,6 @@ func applyConnector(c *cli.Context) error {
 
 	}
 	return nil
-}
-
-func replacePlaceholderValues(haystack string, needle string, value string) string {
-	return strings.ReplaceAll(haystack, needle, value)
 }
 
 func isGithubConnectorYAML(str string) bool {

--- a/constants.go
+++ b/constants.go
@@ -4,11 +4,20 @@ const CONNECTOR_ENDPOINT = "connectors"
 const CONTENT_TYPE_JSON = "application/json"
 const CONTENT_TYPE_YAML = "application/yaml"
 const ENVIRONMENT_ENDPOINT = "environmentsV2"
+const GCP_PROJECT_NAME_PLACEHOLDER = "GCP_PROJECT_NAME"
+const GCP_REGION_NAME_PLACEHOLDER = "GCP_REGION_NAME"
 const GITHUB_SECRET_IDENTIFIER = "harness_gitpat"
 const NG_BASE_URL = "/gateway/ng/api"
 const DEFAULT_PROJECT = "default_project"
 const DEFAULT_ORG = "default"
 const INFRA_ENDPOINT = "infrastructures"
+
+// Enum for multiple platforms
+const (
+	GCP string = "GCP"
+	AWS        = "AWS"
+)
+
 const NOT_IMPLEMENTED = "Command Not_Implemented. Check back later.."
 const PIPELINES_BASE_URL = "/gateway/pipeline/api"
 const PIPELINES_ENDPOINT = "pipelines"

--- a/main.go
+++ b/main.go
@@ -233,7 +233,7 @@ func main() {
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:  "file",
-						Usage: "`YAML` file path for the connector",
+						Usage: "`YAML` file path for the infrastructure",
 					},
 				},
 				Before: func(ctx *cli.Context) error {
@@ -244,6 +244,16 @@ func main() {
 					{
 						Name:  "apply",
 						Usage: "Create a new infrastructure or Update  an existing one.",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:  "gcp-project",
+								Usage: "provide the Google Cloud Platform project name. ",
+							},
+							&cli.StringFlag{
+								Name:  "region",
+								Usage: "provide the Cloud Platform region name. For eg; 1.Creating GCP pipeline then provide gcp-region name, 2.Creating AWS based pipeline then provide aws-region name",
+							},
+						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyInfraDefinition, context)
 						},

--- a/utils.go
+++ b/utils.go
@@ -289,3 +289,8 @@ func mergeMaps(map1 map[string]string, map2 map[string]string) map[string]string
 	}()
 	return mergedMap
 }
+
+// replaces placeholder values in the given yaml content
+func replacePlaceholderValues(haystack string, needle string, value string) string {
+	return strings.ReplaceAll(haystack, needle, value)
+}


### PR DESCRIPTION
Tested locally.

1. When the gcp project and region name are not provided as flags: 
`./harness infra --file harnesscd-example-apps/google_cloud_function/infrastructure-definition.yml apply` 
  Behavior: CLI requests for gcp-project and gcp-region names.
<img width="1162" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/02acf0ee-b57a-48c5-8e4c-dfbf11f3af4e">

2. When the gcp project and region name are provided as flags:
 `./harness infra --file harnesscd-example-apps/google_cloud_function/infrastructure-definition.yml apply --gcp-region us-west1-b --gcp-project plg-play`
Behavior: CLI, goes ahead and updates the infrastructure definition as per the input in the yaml and command line.
<img width="1550" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/fadf379a-9106-4223-8794-23fd92ae0e48">

3. Check all the flags with the help command for infra
`./harness infra apply --help`
<img width="722" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/abcb5936-71d0-4277-adc1-cfa464646f28">
