### PR TITLE
Catch 400 error before json.Unmarshal()

### DIFF
--- a/client.go
+++ b/client.go
@@ -95,6 +95,11 @@ func handleResp(req *http.Request) (respBodyObj ResponseBody, err error) {
 		return
 	}
 
+	if resp.StatusCode >= 400 && resp.StatusCode <= 500 {
+		log.Error("Server returned 'Unauthorized access' code ", resp.StatusCode)
+		return
+	}
+
 	err = json.Unmarshal(respBody, &respBodyObj)
 	if err != nil {
 		log.Fatalln("There was error while parsing the response from server. Exiting...", err)


### PR DESCRIPTION
### Suggestion

Catch authorization errors and notify of that rather than notify of a parsing error that obfuscates the authorization failure.

### Discussion

Following the steps in the CLI section of the [Secrets section](https://developer.harness.io/tutorials/cd-pipelines/serverless/aws-lambda#secrets-1) of the AWS Lambda tutorial, the following command is used:

```
harness login --api-key  --account-id HARNESS_API_TOKEN
```

When the `HARNESS_API_TOKEN` is replaced with my account's token, <sup>1</sup> the command throws the following error:

```
Welcome to Harness CLI!
Login successfully done. Yay!
FATA[2023-10-10T08:44:32-07:00] There was error while parsing the response from server. Exiting... invalid character '<' looking for beginning of value
exit status 1
```

Investigation determined that the server response was a 401 error with what looks like HTML in the body.<sup>2</sup> This is in contrast to the expectation that JSON is the response.

The `io.ReadAll()` function called within `handleResp()` ([here](https://github.com/harness/harness-cli/blob/develop/client.go#L93)) successfully reads the `resp.Body`, but the fact that the body is HTML/XML and not JSON breaks the implicit expectation that the argument to `json.Unmarshal()` is a JSON object ([here](https://github.com/harness/harness-cli/blob/develop/client.go#L98). This results in the error above because `<` is not a valid JSON character.

This message is not helpful, as it does not inform the user of the problem and rather obfuscates what is actually happening. HTML/XML response will likely be supplied with a 4xx error, so my suggestion is to catch the 4xx error prior to `json.Unmarshal()` and inform the user of that, rather than of a parsing error that gives them no useful information.

<hr>
<h3>Footnotes</h3>

<sup>1</sup> During investigation, I came to the conclusion that the `PromptAccountDetails()` function expected this command to be _something like_: 

```harness login --api-key HARNESS_API_TOKEN  --account-id ACCOUNT_NAME```

because the original command caused the `AuthHeaderKey()` ([here](https://github.com/harness/harness-cli/blob/develop/client.go#L58)) function to set the headers to `map[Content-Type:[application/json] X-Api-Key:[--account-id]]` and the [account prompt](https://github.com/harness/harness-cli/blob/develop/prompts.go#L10) to be hit.

<sup>2</sup> This PR simply catches the 400 level error and does not address the problem of the Harness CLI encountering an authorization error and returning HTML. That's something that should be addressed by the Harness team and not an internet rando.