### PR TITLE
fix: [PLG-3051]: Fix the issue with namespace for GitOps application creation

### DIFF
--- a/gitops-application.go
+++ b/gitops-application.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/urfave/cli/v2"
 	"harness/client"
 	"harness/defaults"
 	"harness/shared"
 	"harness/telemetry"
 	. "harness/types"
 	. "harness/utils"
+
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
 )
 
 func applyGitopsApplications(c *cli.Context) error {
@@ -126,7 +127,6 @@ func createGitOpsApplicationPayload(requestBody map[string]interface{}) GitOpsAp
 					Serviceref: ValueToString(GetNestedValue(requestBody, "gitops", "application", "metadata", "labels", "harness.io/serviceRef").(string)),
 				},
 				Name:        ValueToString(GetNestedValue(requestBody, "gitops", "name").(string)),
-				Namespace:   ValueToString(GetNestedValue(requestBody, "gitops", "application", "metadata", "namespace").(string)),
 				ClusterName: ValueToString(GetNestedValue(requestBody, "gitops", "application", "metadata", "clusterName").(string)),
 			},
 			Spec: Spec{
@@ -149,7 +149,6 @@ func createGitOpsApplicationPUTPayload(requestBody map[string]interface{}) GitOp
 	putApp := GitOpsApplication{
 		Application{
 			Metadata: Metadata{
-				Namespace: ValueToString(GetNestedValue(requestBody, "gitops", "application", "metadata", "namespace").(string)),
 				Labels: Labels{
 					Serviceref: ValueToString(GetNestedValue(requestBody, "gitops", "application", "metadata", "labels", "harness.io/serviceRef").(string)),
 					Envref:     ValueToString(GetNestedValue(requestBody, "gitops", "application", "metadata", "labels", "harness.io/envRef").(string)),


### PR DESCRIPTION
Created a fresh namespace and then created an agent in that namespace.
`kubectl create ns gitops-namespace-nov28`
`kubectl apply -f gitops-agent.yml -n gitops-namespace-nov28`
Followed with the entity creation as follows:

<img width="1567" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/d10c7f58-d268-48b9-a678-3d8b82b08311">

<img width="1558" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/ae5b17f5-eee2-4cf2-ad05-64b6a9bc5014">

<img width="1553" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/c7391345-5482-4f3a-95c8-4bea7bfa0705">

View of Healthy application created from the app:
<img width="1575" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/df18cb85-df50-498c-9c45-1093db6893e4">

