### PR TITLE
feat: [PLG-3017] Adding support for org and project flags in the cd-pipeline entities creation

### DIFF
--- a/gitops-cluster.go
+++ b/gitops-cluster.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/urfave/cli/v2"
 	"harness/client"
 	"harness/defaults"
 	"harness/shared"
 	"harness/telemetry"
 	. "harness/types"
 	. "harness/utils"
+
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
 )
 
 // create or update a Gitops Cluster
@@ -34,7 +35,10 @@ func applyCluster(c *cli.Context) error {
 		println(GetColoredText("Please enter valid cluster yaml file", color.FgRed))
 	}
 	identifier := ValueToString(GetNestedValue(requestBody, "gitops", "identifier").(string))
-	projectIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "projectIdentifier").(string))
+	projectIdentifier := c.String("project")
+	if projectIdentifier == "" {
+		projectIdentifier = ValueToString(GetNestedValue(requestBody, "gitops", "projectIdentifier").(string))
+	}
 	orgIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "orgIdentifier").(string))
 	createOrUpdateClusterURL := GetUrlWithQueryParams("", baseURL, defaults.GITOPS_CLUSTER_ENDPOINT, map[string]string{
 		"identifier":        identifier,

--- a/main.go
+++ b/main.go
@@ -6,10 +6,11 @@ import (
 	"harness/auth"
 	"os"
 
+	. "harness/shared"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 	"github.com/urfave/cli/v2/altsrc"
-	. "harness/shared"
 )
 
 var Version = "development"
@@ -131,6 +132,14 @@ func main() {
 								Name:  "domain",
 								Usage: "domain for cloud data center",
 							},
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "org-id",
+								Usage: "provide an Organization Identifier",
+							}),
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "project-id",
+								Usage: "provide a Project Identifier",
+							}),
 						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applySecret, context)
@@ -154,6 +163,16 @@ func main() {
 						Name:  "file",
 						Usage: "`YAML` file path for the service",
 					},
+					altsrc.NewStringFlag(&cli.StringFlag{
+						Name:        "org-id",
+						Usage:       "provide an Organization Identifier",
+						Destination: &CliCdRequestData.OrgName,
+					}),
+					altsrc.NewStringFlag(&cli.StringFlag{
+						Name:        "project-id",
+						Usage:       "provide an Project Identifier",
+						Destination: &CliCdRequestData.ProjectName,
+					}),
 				},
 				Before: func(ctx *cli.Context) error {
 					auth.HydrateCredsFromPersistence(ctx)
@@ -176,6 +195,14 @@ func main() {
 								Name:  "cloud-region",
 								Usage: "provide the Google Cloud Platform bucket name.",
 							},
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "org-id",
+								Usage: "provide an Organization Identifier",
+							}),
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "project-id",
+								Usage: "provide a Project Identifier",
+							}),
 						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyService, context)
@@ -208,6 +235,16 @@ func main() {
 					{
 						Name:  "apply",
 						Usage: "Create a new environment or Update  an existing one.",
+						Flags: []cli.Flag{
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "org-id",
+								Usage: "provide an Organization Identifier",
+							}),
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "project-id",
+								Usage: "provide a Project Identifier",
+							}),
+						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyEnvironment, context)
 						},
@@ -273,6 +310,14 @@ func main() {
 								Name:  "port",
 								Usage: "port for the physical data center connector",
 							},
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "org-id",
+								Usage: "provide an Organization Identifier",
+							}),
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "project-id",
+								Usage: "provide a Project Identifier",
+							}),
 						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyConnector, context)
@@ -408,6 +453,14 @@ func main() {
 								Name:  "instance-name",
 								Usage: "instance name for the cloud provider for PDC Infrastructure",
 							},
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "org-id",
+								Usage: "provide an Organization Identifier",
+							}),
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "project-id",
+								Usage: "provide a Project Identifier",
+							}),
 						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyInfraDefinition, context)
@@ -431,6 +484,16 @@ func main() {
 						Name:  "file",
 						Usage: "`YAML` file path for the pipeline",
 					},
+					altsrc.NewStringFlag(&cli.StringFlag{
+						Name:        "org-id",
+						Usage:       "provide an Organization Identifier",
+						Destination: &CliCdRequestData.OrgName,
+					}),
+					altsrc.NewStringFlag(&cli.StringFlag{
+						Name:        "project-id",
+						Usage:       "provide a Project Identifier",
+						Destination: &CliCdRequestData.ProjectName,
+					}),
 				},
 				Before: func(ctx *cli.Context) error {
 					auth.HydrateCredsFromPersistence(ctx)

--- a/services.go
+++ b/services.go
@@ -28,6 +28,8 @@ func applyService(c *cli.Context) error {
 	cloudProjectName = c.String("cloud-project")
 	cloudBucketName = c.String("cloud-bucket")
 	cloudRegionName = c.String("cloud-region")
+	orgIdentifier := c.String("org-id")
+	projectIdentifier := c.String("project-id")
 	fmt.Println("Trying to create or update service using the yaml=",
 		GetColoredText(filePath, color.FgCyan))
 	createOrUpdateSvcURL := GetUrlWithQueryParams("", baseURL, defaults.SERVICES_ENDPOINT, map[string]string{
@@ -42,11 +44,18 @@ func applyService(c *cli.Context) error {
 	}
 	identifier := ValueToString(GetNestedValue(requestBody, "service", "identifier").(string))
 	name := ValueToString(GetNestedValue(requestBody, "service", "name").(string))
+
+	if orgIdentifier == "" {
+		orgIdentifier = defaults.DEFAULT_ORG
+	}
+	if projectIdentifier == "" {
+		projectIdentifier = defaults.DEFAULT_PROJECT
+	}
 	//setup payload for svc create / update
 	svcPayload := HarnessService{Identifier: identifier, Name: name,
-		ProjectIdentifier: defaults.DEFAULT_PROJECT, OrgIdentifier: defaults.DEFAULT_ORG, Yaml: content}
+		ProjectIdentifier: projectIdentifier, OrgIdentifier: orgIdentifier, Yaml: content}
 	entityExists := GetEntity(baseURL, fmt.Sprintf("servicesV2/%s", identifier),
-		defaults.DEFAULT_PROJECT, defaults.DEFAULT_ORG, map[string]string{})
+		projectIdentifier, orgIdentifier, map[string]string{})
 	var err error
 	if !entityExists {
 		println("Creating service with id: ", GetColoredText(identifier, color.FgGreen))


### PR DESCRIPTION
Tested all the entity creation in the CD Pipeline flow as follows:

```
 ./harness secret --token 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 apply --project-id cmdProject 
Secret with identifier [harness_gitpat] is not found in the given scope
Creating secret with default id:  harness_gitpat
createSecretURL: https://app.harness.io/gateway/ng/api/v2/secrets?projectIdentifier=cmdProject&orgIdentifier=default&accountIdentifier=YxQTDwg5Rwuj7m0AznWGZA
Successfully created secret with id= harness_gitpat
```

`./harness connector --file harnesscd-example-apps/guestbook/harnesscd-pipeline/github-connector.yml apply --git-user neelam-harness --project-id cmdProject`
<img width="1590" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/12a8e6d2-2cd9-4d41-b2b1-8f98ee402eb6">

`./harness service --file harnesscd-example-apps/guestbook/harnesscd-pipeline/service.yml apply --org-id default --project-id cmdProject
`
<img width="1618" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/c7369905-3b1b-4a18-88e0-b7229cc67ffb">

`./harness environment --file harnesscd-example-apps/guestbook/harnesscd-pipeline/environment.yml apply --org-id default --project-id cmdProject`
<img width="1618" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/ab217a38-b8f9-4e03-98ce-625f74519a14">

 `./harness infrastructure  --file  harnesscd-example-apps/guestbook/harnesscd-pipeline/infrastructure-definition.yml apply --org-id default --project-id cmdProject`
<img width="1620" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/d4388da2-135e-4c68-89f2-f72e5260a59a">
