### PR TITLE
feat: [PLG-3017] Adding support for org and project flags in the cd-gitops flow

### DIFF
--- a/gitops-application.go
+++ b/gitops-application.go
@@ -15,6 +15,9 @@ import (
 
 func applyGitopsApplications(c *cli.Context) error {
 	filePath := c.String("file")
+	orgIdentifier := c.String("org-id")
+	projectIdentifier := c.String("project-id")
+
 	baseURL := GetBaseUrl(c, defaults.GITOPS_BASE_URL)
 	if filePath == "" {
 		fmt.Println("Please enter valid filename")
@@ -33,8 +36,12 @@ func applyGitopsApplications(c *cli.Context) error {
 	if requestBody == nil {
 		println(GetColoredText("Please enter valid repository yaml file", color.FgRed))
 	}
-	orgIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "orgIdentifier").(string))
-	projectIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "projectIdentifier").(string))
+	if orgIdentifier == "" {
+		orgIdentifier = ValueToString(GetNestedValue(requestBody, "gitops", "orgIdentifier").(string))
+	}
+	if projectIdentifier == "" {
+		projectIdentifier = ValueToString(GetNestedValue(requestBody, "gitops", "projectIdentifier").(string))
+	}
 	clusterIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "clusterIdentifier").(string))
 	repoIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "repoIdentifier").(string))
 

--- a/gitops-cluster.go
+++ b/gitops-cluster.go
@@ -16,6 +16,9 @@ import (
 // create or update a Gitops Cluster
 func applyCluster(c *cli.Context) error {
 	filePath := c.String("file")
+	orgIdentifier := c.String("org-id")
+	projectIdentifier := c.String("project-id")
+
 	baseURL := GetBaseUrl(c, defaults.GITOPS_BASE_URL)
 	if filePath == "" {
 		fmt.Println("Please enter valid filename")
@@ -35,11 +38,15 @@ func applyCluster(c *cli.Context) error {
 		println(GetColoredText("Please enter valid cluster yaml file", color.FgRed))
 	}
 	identifier := ValueToString(GetNestedValue(requestBody, "gitops", "identifier").(string))
-	projectIdentifier := c.String("project")
+
 	if projectIdentifier == "" {
 		projectIdentifier = ValueToString(GetNestedValue(requestBody, "gitops", "projectIdentifier").(string))
 	}
-	orgIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "orgIdentifier").(string))
+
+	if orgIdentifier == "" {
+		orgIdentifier = ValueToString(GetNestedValue(requestBody, "gitops", "orgIdentifier").(string))
+	}
+
 	createOrUpdateClusterURL := GetUrlWithQueryParams("", baseURL, defaults.GITOPS_CLUSTER_ENDPOINT, map[string]string{
 		"identifier":        identifier,
 		"accountIdentifier": shared.CliCdRequestData.Account,

--- a/gitops-repository.go
+++ b/gitops-repository.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/urfave/cli/v2"
 	"harness/client"
 	"harness/defaults"
 	"harness/shared"
 	"harness/telemetry"
 	. "harness/types"
 	. "harness/utils"
+
+	"github.com/fatih/color"
+	"github.com/urfave/cli/v2"
 )
 
 var agentIdentifier = ""
@@ -17,6 +18,9 @@ var agentIdentifier = ""
 // create or update a Gitops Repository
 func applyRepository(c *cli.Context) error {
 	filePath := c.String("file")
+	orgIdentifier := c.String("org-id")
+	projectIdentifier := c.String("project-id")
+
 	baseURL := GetBaseUrl(c, defaults.GITOPS_BASE_URL)
 	if filePath == "" {
 		fmt.Println("Please enter valid filename")
@@ -36,8 +40,14 @@ func applyRepository(c *cli.Context) error {
 		println(GetColoredText("Please enter valid repository yaml file", color.FgRed))
 	}
 	identifier := ValueToString(GetNestedValue(requestBody, "gitops", "identifier").(string))
-	projectIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "projectIdentifier").(string))
-	orgIdentifier := ValueToString(GetNestedValue(requestBody, "gitops", "orgIdentifier").(string))
+	if projectIdentifier == "" {
+		projectIdentifier = ValueToString(GetNestedValue(requestBody, "gitops", "projectIdentifier").(string))
+	}
+
+	if orgIdentifier == "" {
+		orgIdentifier = ValueToString(GetNestedValue(requestBody, "gitops", "orgIdentifier").(string))
+	}
+
 	createOrUpdateRepositoryURL := GetUrlWithQueryParams("", baseURL, defaults.GITOPS_REPOSITORY_ENDPOINT, map[string]string{
 		"identifier":        identifier,
 		"accountIdentifier": shared.CliCdRequestData.Account,

--- a/main.go
+++ b/main.go
@@ -355,6 +355,14 @@ func main() {
 								Name:  "agent-identifier",
 								Usage: "provide GitOps Agent Identifier.",
 							},
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "org-id",
+								Usage: "provide an Organization Identifier",
+							}),
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "project-id",
+								Usage: "provide a Project Identifier",
+							}),
 						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyGitopsApplications, context)
@@ -385,6 +393,14 @@ func main() {
 								Name:  "agent-identifier",
 								Usage: "provide GitOps Agent Identifier.",
 							},
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "org-id",
+								Usage: "provide an Organization Identifier",
+							}),
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "project-id",
+								Usage: "provide a Project Identifier",
+							}),
 						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyCluster, context)
@@ -415,6 +431,14 @@ func main() {
 								Name:  "agent-identifier",
 								Usage: "provide GitOps Agent Identifier.",
 							},
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "org-id",
+								Usage: "provide an Organization Identifier",
+							}),
+							altsrc.NewStringFlag(&cli.StringFlag{
+								Name:  "project-id",
+								Usage: "provide a Project Identifier",
+							}),
 						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyRepository, context)


### PR DESCRIPTION
> 1.a. GitOps Cluster creation with project-id override
 
`./harness gitops-cluster --file harnesscd-example-apps/guestbook/harness-gitops/cluster.yml apply --agent-identifier gitopsagentdec20 --project-id cmdProject`
<img width="1117" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/4ea0f35c-c95f-4484-8d2e-4a58ce12a5b8">


<img width="1148" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/f68851f9-fb81-450d-b3c4-9013cbb40ec0">


> 1.b GitOps Cluster creation with project-id and org-id override

`./harness gitops-cluster --file harnesscd-example-apps/guestbook/harness-gitops/cluster.yml apply --agent-identifier gitopsagentdec20 --project-id cmdProject --org-id default`
<img width="1116" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/81f726d2-3557-4da6-a3a3-d55e02c55ccd">

> 2.a. GitOps repository creation with the project-id override

`./harness gitops-repository --file harnesscd-example-apps/guestbook/harness-gitops/repository.yml apply --agent-identifi
er gitopsagentdec20 --project-id cmdProject
`
<img width="1177" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/229ca3fd-6cd2-44af-adc5-cebbc67212fa">


> 2.b. GitOps repository creation with the project-id and org-id override
 
`./harness gitops-repository --file harnesscd-example-apps/guestbook/harness-gitops/repository.yml apply --agent-identifier gitopsagentdec20 --project-id cmdProject --org-id default`
<img width="1174" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/e8ee6c9a-0a0e-4bac-be22-b09c96eab417">


> 3.a GitOps application creation with project-id override

` ./harness gitops-application --file harnesscd-example-apps/guestbook/harness-gitops/application.yml apply --agent-identifier gitopsagentdec20 --project-id cmdProject`
<img width="1278" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/46e368df-1622-4a72-ba9d-7dc8d1692903">

<img width="1254" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/33ae51e9-76b5-4f96-a58e-42d14670387f">

> 3.b. GitOps application creation with project-id and org-id override

`./harness gitops-application --file harnesscd-example-apps/guestbook/harness-gitops/application.yml apply --agent-identifier gitopsagentdec20 --project-id cmdProject  --org-id default`
<img width="1260" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/b40cd580-dfac-4ff7-9899-078de322f490">

