### PR TITLE
feat: [PLG-3129]: Require user input secret name + move token arg in secret command

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,10 +86,6 @@ func main() {
 				Aliases: []string{"secret-token"},
 				Usage:   "Secrets specific commands. eg: apply (create/update), delete",
 				Flags: append(globalFlags,
-					altsrc.NewStringFlag(&cli.StringFlag{
-						Name:  "token",
-						Usage: "Specify your Secret Token",
-					}),
 					&cli.StringFlag{
 						Name:  "file",
 						Usage: "File path for the secret",
@@ -112,6 +108,14 @@ func main() {
 						Name:  "apply",
 						Usage: "Create a new secret or Update  an existing one.",
 						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name: "token",
+								Usage: "Specify your Secret Token",
+							},
+							&cli.StringFlag{
+								Name: "secret-name",
+								Usage: "provide the secret name",
+							},
 							&cli.StringFlag{
 								Name:  "secret-type",
 								Usage: "provide the secret type.",

--- a/secret.go
+++ b/secret.go
@@ -123,7 +123,7 @@ func applySecret(ctx *cli.Context) error {
 		secretBody = createSecret(orgIdentifier, projectIdentifier, secretName, secretIdentifier, gitPat, SecretText, SSHWINRMSecretData{})
 	}
 	if !entityExists {
-		println("Creating secret with default id: ", utils.GetColoredText(secretIdentifier, color.FgCyan))
+		println("Creating secret with id: ", utils.GetColoredText(secretIdentifier, color.FgCyan))
 		if requiresFile {
 			payload, header, _ := readSecretFromPath(filePath, secretBody)
 
@@ -365,7 +365,7 @@ func createSSHSecret(orgIdentifier string, projIdentifier string, filepath strin
 		secretBody = createSecret(orgIdentifier, projIdentifier, secretIdentifier, secretIdentifier, "", SSHKey, SSHWINRMSecretData{Port: port, Username: username, Key: defaults.SSH_KEY_FILE_SECRET_IDENTIFIER})
 	}
 	if !fileSecretExists {
-		println("Creating secret with default id: ", utils.GetColoredText(secretIdentifier, color.FgCyan))
+		println("Creating secret with id: ", utils.GetColoredText(secretIdentifier, color.FgCyan))
 		if isSSHFileSecret {
 			payload, header, _ := readSecretFromPath(filepath, secretBody)
 
@@ -456,7 +456,7 @@ func createWinRMSecret(orgIdentifier string, projIdentifier string, secretIdenti
 		secretBody = createSecret(orgIdentifier, projIdentifier, secretIdentifier, secretIdentifier, "", WinRM, SSHWINRMSecretData{Port: port, Username: username, Password: defaults.WINRM_PASSWORD_SECRET_IDENTIFIER, Domain: domain, AuthType: authType})
 	}
 	if !secretExists {
-		println("Creating secret with default id: ", utils.GetColoredText(secretIdentifier, color.FgCyan))
+		println("Creating secret with id: ", utils.GetColoredText(secretIdentifier, color.FgCyan))
 
 		_, err = client.Post(createSecretURL, shared.CliCdRequestData.AuthToken, secretBody, defaults.CONTENT_TYPE_JSON, nil)
 

--- a/secret.go
+++ b/secret.go
@@ -53,7 +53,7 @@ func applySecret(ctx *cli.Context) error {
 		return nil
 	}
 	if secretName == "" {
-		println("Secret name cannot be empty")
+		println("Secret name cannot be empty. Please provide --secret-name.")
 		return nil
 	}
 	if !requiresFile && password == "" && gitPat == "" {
@@ -136,8 +136,6 @@ func applySecret(ctx *cli.Context) error {
 
 		} else {
 			fmt.Println("createSecretURL: " + createSecretURL)
-			fmt.Println("Printing SecretBody: ")
-			fmt.Println(secretBody)
 			_, err = client.Post(createSecretURL, shared.CliCdRequestData.AuthToken, secretBody, defaults.CONTENT_TYPE_JSON, nil)
 		}
 		if err == nil {


### PR DESCRIPTION
- Changes secret command syntax to `harness secret apply --secret-name --token-name`
- Requires `secret-name` parameter for user to set name of secret
- Sets Secret Identifier from secret name