### PR TITLE
feat: [PLG-3112] Add a flag to accept github username for creating Gitops-Application

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,11 +109,11 @@ func main() {
 						Usage: "Create a new secret or Update  an existing one.",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
-								Name: "token",
+								Name:  "token",
 								Usage: "Specify your Secret Token",
 							},
 							&cli.StringFlag{
-								Name: "secret-name",
+								Name:  "secret-name",
 								Usage: "provide the secret name",
 							},
 							&cli.StringFlag{
@@ -358,6 +358,10 @@ func main() {
 							&cli.StringFlag{
 								Name:  "agent-identifier",
 								Usage: "provide GitOps Agent Identifier.",
+							},
+							&cli.StringFlag{
+								Name:  "git-user",
+								Usage: "provide your Github username",
 							},
 							altsrc.NewStringFlag(&cli.StringFlag{
 								Name:  "org-id",


### PR DESCRIPTION
Sample application.yaml used for testing:
```
gitops:
  name: gitops-application
  projectIdentifier: default_project
  orgIdentifier: default
  type: application
  application:
    metadata:
      clusterName: gitops_cluster
      labels:
        harness.io/serviceRef: ""
        harness.io/envRef: ""
    spec:
      source:
        repoURL: https://github.com/GITHUB_USERNAME/harness-gitops-workshop
        path: configs/git-generator-files-discovery
        targetRevision: main
      destination:
        server: https://kubernetes.default.svc
        namespace: default
  agentIdentifier: AGENT_NAME
  clusterIdentifier: gitopscluster
  repoIdentifier: gitopsrepo
```
Test Scenarios:
1. Create GitOps application, with the new sample yaml above with reference to https://github.com/neelam-harness/harness-gitops-workshop/blob/main/cli-manifests/gitops-app.yaml 

![image](https://github.com/harness/harness-cli/assets/117125370/5261e963-7197-4b87-aa33-f9dd2b88feb7)
![image](https://github.com/harness/harness-cli/assets/117125370/32c0b83d-42d5-49a0-b521-27a8473216e8)


2. Create Gitops application, with the original yaml as here: https://github.com/nicklotz/harnesscd-example-apps/blob/master/guestbook/harness-gitops/application.yml 
![image](https://github.com/harness/harness-cli/assets/117125370/d9c0f3d2-226c-4e77-8009-1147c8c5f41c)
![image](https://github.com/harness/harness-cli/assets/117125370/4cb5cb26-5343-45b2-b32c-4b3fba645c52)

