### PR TITLE
feat: [PLG-3122]: Removing un-necessary check on project-id that was checked in by mistake in previous commit

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -55,9 +55,6 @@ func applyPipeline(c *cli.Context) error {
 	} else {
 		orgIdentifier = ValueToString(GetNestedValue(requestBody, "pipeline", "orgIdentifier").(string))
 	}
-	if projectIdentifier == "" {
-		projectIdentifier = ValueToString(GetNestedValue(requestBody, "connector", "projectIdentifier").(string))
-	}
 	if projectIdentifier != "" {
 		content = ReplacePlaceholderValues(content, defaults.DEFAULT_PROJECT, projectIdentifier)
 	} else {


### PR DESCRIPTION
Tested CD-Pipeline flow end to end:
<img width="1620" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/af628bea-f80d-4288-a81e-5821c6613482">
<img width="1624" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/5ecfb5b2-0cf7-49ae-8185-73e441de2ae1">
<img width="1393" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/25cd8b11-64ea-4361-88d1-35fb364a4206">

