### PR TITLE
Add contributor's guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To propose a change to the codebase, open a [pull request](https://github.com/ha
 
 ## Development
 
-The Harness CLI is a Go module that interacts heavily with the [Harness API](https://apidocs.harness.io/). Most functionality requires authentication to a Harness account (SaaS or self-managed). You can sign up for free account [here](https://app.harness.io/auth/#/signup?utm_source=harness_io&utm_medium=cta&utm_campaign=platform&utm_content=main_nav). 
+The Harness CLI is a Go module that interacts heavily with the [Harness API](https://apidocs.harness.io/). Most functionality requires authentication to a Harness account (SaaS or self-managed). You can sign up for a free account [here](https://app.harness.io/auth/#/signup?utm_source=harness_io&utm_medium=cta&utm_campaign=platform&utm_content=main_nav). You'll then want to create an [API token](https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/) for authenticating with the CLI.
 
 ### Build and test locally
 1. Ensure you have Go version 1.19 or later [installed](https://go.dev/doc/install). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To propose a change to the codebase, open a [pull request](https://github.com/ha
 
 ## Development
 
-The Harness CLI is a Go module that interacts heavily with the [Harness API](https://apidocs.harness.io/). Most functionality requires authentication to a Harness account (SaaS or self-managed). You can sign up for a free account [here](https://app.harness.io/auth/#/signup?utm_source=harness_io&utm_medium=cta&utm_campaign=platform&utm_content=main_nav). You'll then want to create an [API token](https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/) for authenticating with the CLI.
+The Harness CLI is a Go module that interacts heavily with the [Harness API](https://apidocs.harness.io/). Most functionality requires authentication to a Harness account (SaaS or self-managed). You can sign up for a free account [here](https://app.harness.io/auth/#/signup?utm_source=harness_io&utm_medium=cta&utm_campaign=platform&utm_content=main_nav).
 
 ### Build and test locally
 1. Ensure you have Go version 1.19 or later [installed](https://go.dev/doc/install). 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to the Harness CLI
+
+Thank you for considering contributing to the Harness CLI! Contributions fall into a couple of categories:
+
+### Bugs and feature requests
+
+To report a bug or request a feature enhancement, create a [GitHub issue](https://github.com/harness/harness-cli/issues).
+
+### Code contributions
+
+To propose a change to the codebase, open a [pull request](https://github.com/harness/harness-cli/pulls). A maintainer will be happy to triage and ask clarifying questions as needed. We also ask that you build and test proposed changes yourself, and include any relevant output and/or screenshots in the PR.
+
+## Development
+
+The Harness CLI is a Go module that interacts heavily with the [Harness API](https://apidocs.harness.io/). Most functionality requires authentication to a Harness account (SaaS or self-managed). You can sign up for free account [here](https://app.harness.io/auth/#/signup?utm_source=harness_io&utm_medium=cta&utm_campaign=platform&utm_content=main_nav). 
+
+### Build and test locally
+1. Ensure you have Go version 1.19 or later [installed](https://go.dev/doc/install). 
+2. [Fork](https://github.com/harness/harness-cli/fork) this repository, then [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) locally.
+3. Navigate into the project directory.
+  ```shell
+   cd harness-cli/
+  ```
+4. Make your desired changes to the source code.
+5. From the `harness-cli/` directory, compile a new executable with your changes.
+  ```shell
+   go build -o harness
+  ```
+6. Run and test your changes.
+  ```shell
+  ./harness [global options] command [command options] [arguments...]
+  ```
+7. If contributing, push to your fork and [submit a pull request](https://github.com/harness/harness-cli/pulls). Include relevant output and/or screenshots from local tests.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We welcome contributions. Please see the [Contributors Guide](CONTRIBUTING.md) f
 
 To reach us with feedback and questions:
 - Join the [Harness Community](https://join.slack.com/t/harnesscommunity/shared_invite/zt-1h2cy1up2-Bf3MQQvKTf~YkVcsnkJ5pw) Slack space
-- Refer to [Harness Community Communications Guide](https://github.com/harness-community/overview/blob/main/community_communication_guide.md) to interact with the wider community users/contributors.
+- Refer to the [Harness Community Communications Guide](https://github.com/harness-community/overview/blob/main/community_communication_guide.md) to interact with the wider community users/contributors.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ We ask all of our users and contributors to adhere to the [Harness Code of Condu
 
 ## Get Involved
 
-We welcome your feedback and ideas. Here's how to reach us with feedback and questions: Join [Harness Community](https://join.slack.com/t/harnesscommunity/shared_invite/zt-1h2cy1up2-Bf3MQQvKTf~YkVcsnkJ5pw) Slack space. Refer to [Harness Community Communications Guide](https://github.com/harness-community/overview/blob/main/community_communication_guide.rst) to interact with the wider community users/contributors.
+We welcome contributions. Please see the [Contributors Guide](CONTRIBUTING.md) for details on how to contribute.
+
+To reach us with feedback and questions:
+- Join the [Harness Community](https://join.slack.com/t/harnesscommunity/shared_invite/zt-1h2cy1up2-Bf3MQQvKTf~YkVcsnkJ5pw) Slack space
+- Refer to [Harness Community Communications Guide](https://github.com/harness-community/overview/blob/main/community_communication_guide.md) to interact with the wider community users/contributors.
 
 ## License
 


### PR DESCRIPTION
Currently the README refers users to the Harness Community Slack for general engagement. This PR adds a contributor's guide for prospective developers, with instructions for:

- Reporting bugs and feature requests
- Opening PRs
- Building and developing locally

A link to the contributor guide is also added to the "Get Involved" section of the README