### PR TITLE
feat: [PL-51125]: Remove the unimplemented option LIST and DELETE from the connector command

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,7 +265,7 @@ func main() {
 			{
 				Name:    "connector",
 				Aliases: []string{"conn"},
-				Usage:   "Connector specific commands, eg: apply (create/update), delete, list",
+				Usage:   "Connector specific commands, eg: apply (create/update)",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
 						Name:  "file",
@@ -329,13 +329,6 @@ func main() {
 						},
 						Action: func(context *cli.Context) error {
 							return cliWrapper(applyConnector, context)
-						},
-					},
-					{
-						Name:  "delete",
-						Usage: "Delete a connector.",
-						Action: func(context *cli.Context) error {
-							return cliWrapper(deleteConnector, context)
 						},
 					},
 				},


### PR DESCRIPTION
Remove the unimplemented option LIST and DELETE from the connector command

Tested:
<img width="628" alt="image" src="https://github.com/harness/harness-cli/assets/117125370/f7cc58df-d9e0-4410-872c-37d7a47927c3">
