### PR TITLE
feat: [CLI-56856]: Add configurable request timeout

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -106,9 +106,9 @@ type accountResponse struct {
 
 // validateCredentials validates the provided credentials by making an API call
 func validateCredentials(apiURL, token, accountID string) error {
-	// Create HTTP client with configurable timeout
+	// Create HTTP client with reasonable timeout
 	client := &http.Client{
-		Timeout: time.Duration(config.Global.TimeoutSeconds) * time.Second,
+		Timeout: 10 * time.Second,
 	}
 
 	// Build the request URL

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -106,9 +106,9 @@ type accountResponse struct {
 
 // validateCredentials validates the provided credentials by making an API call
 func validateCredentials(apiURL, token, accountID string) error {
-	// Create HTTP client with reasonable timeout
+	// Create HTTP client with configurable timeout
 	client := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: time.Duration(config.Global.TimeoutSeconds) * time.Second,
 	}
 
 	// Build the request URL

--- a/cmd/hc/main.go
+++ b/cmd/hc/main.go
@@ -43,6 +43,11 @@ func main() {
       Find more information at:
             https://developer.harness.io/docs/platform/automation/cli/reference/#v1.0.0-hc`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Validate timeout range
+			if config.Global.TimeoutSeconds < 0 || config.Global.TimeoutSeconds > config.MaxTimeoutSeconds {
+				return fmt.Errorf("invalid --timeout value %d: must be between 0 and %d", config.Global.TimeoutSeconds, config.MaxTimeoutSeconds)
+			}
+
 			// Skip loading config for auth commands, version, and upgrade
 			if cmd.CommandPath() == "hc auth" ||
 				cmd.CommandPath() == "hc auth login" ||
@@ -154,6 +159,10 @@ func main() {
 		timeout, err := strconv.Atoi(envVal)
 		if err != nil {
 			fmt.Printf("Invalid HARNESS_TIMEOUT_SECONDS value %q: must be an integer\n", envVal)
+			os.Exit(1)
+		}
+		if timeout < 0 || timeout > config.MaxTimeoutSeconds {
+			fmt.Printf("Invalid HARNESS_TIMEOUT_SECONDS value %d: must be between 0 and %d\n", timeout, config.MaxTimeoutSeconds)
 			os.Exit(1)
 		}
 		config.Global.TimeoutSeconds = timeout

--- a/cmd/hc/main.go
+++ b/cmd/hc/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"runtime/pprof"
 	"time"
 
@@ -103,6 +104,8 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&config.Global.OrgID, "org", "", "Org (overrides saved config)")
 	rootCmd.PersistentFlags().StringVar(&config.Global.ProjectID, "project", "", "Project (overrides saved config)")
 	rootCmd.PersistentFlags().StringVar(&config.Global.Format, "format", "table", "Format of the result")
+	rootCmd.PersistentFlags().IntVar(&config.Global.TimeoutSeconds, "timeout", config.DefaultTimeoutSeconds,
+		"Request timeout in seconds (0 for no timeout)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging to console")
 
 	// Load auth config
@@ -146,6 +149,11 @@ func main() {
 	}
 	if envVal := os.Getenv("HARNESS_PROJECT_ID"); envVal != "" {
 		config.Global.ProjectID = envVal
+	}
+	if envVal := os.Getenv("HARNESS_TIMEOUT"); envVal != "" {
+		if timeout, err := strconv.Atoi(envVal); err == nil {
+			config.Global.TimeoutSeconds = timeout
+		}
 	}
 
 	// Add main command groups

--- a/cmd/hc/main.go
+++ b/cmd/hc/main.go
@@ -43,9 +43,9 @@ func main() {
       Find more information at:
             https://developer.harness.io/docs/platform/automation/cli/reference/#v1.0.0-hc`),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// Validate timeout range
-			if config.Global.TimeoutSeconds < 0 || config.Global.TimeoutSeconds > config.MaxTimeoutSeconds {
-				return fmt.Errorf("invalid --timeout value %d: must be between 0 and %d", config.Global.TimeoutSeconds, config.MaxTimeoutSeconds)
+			// Validate timeout is not negative
+			if config.Global.TimeoutSeconds < 0 {
+				return fmt.Errorf("invalid --timeout value %d: must be 0 (no timeout) or a positive number of seconds", config.Global.TimeoutSeconds)
 			}
 
 			// Skip loading config for auth commands, version, and upgrade
@@ -110,7 +110,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&config.Global.ProjectID, "project", "", "Project (overrides saved config)")
 	rootCmd.PersistentFlags().StringVar(&config.Global.Format, "format", "table", "Format of the result")
 	rootCmd.PersistentFlags().IntVar(&config.Global.TimeoutSeconds, "timeout", config.DefaultTimeoutSeconds,
-		"Request timeout in seconds (0 for no timeout)")
+		"Request timeout in seconds (default: no timeout)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging to console")
 
 	// Load auth config
@@ -161,8 +161,8 @@ func main() {
 			fmt.Printf("Invalid HARNESS_TIMEOUT_SECONDS value %q: must be an integer\n", envVal)
 			os.Exit(1)
 		}
-		if timeout < 0 || timeout > config.MaxTimeoutSeconds {
-			fmt.Printf("Invalid HARNESS_TIMEOUT_SECONDS value %d: must be between 0 and %d\n", timeout, config.MaxTimeoutSeconds)
+		if timeout < 0 {
+			fmt.Printf("Invalid HARNESS_TIMEOUT_SECONDS value %d: must be 0 (no timeout) or a positive number of seconds\n", timeout)
 			os.Exit(1)
 		}
 		config.Global.TimeoutSeconds = timeout

--- a/cmd/hc/main.go
+++ b/cmd/hc/main.go
@@ -150,10 +150,13 @@ func main() {
 	if envVal := os.Getenv("HARNESS_PROJECT_ID"); envVal != "" {
 		config.Global.ProjectID = envVal
 	}
-	if envVal := os.Getenv("HARNESS_TIMEOUT"); envVal != "" {
-		if timeout, err := strconv.Atoi(envVal); err == nil {
-			config.Global.TimeoutSeconds = timeout
+	if envVal := os.Getenv("HARNESS_TIMEOUT_SECONDS"); envVal != "" {
+		timeout, err := strconv.Atoi(envVal)
+		if err != nil {
+			fmt.Printf("Invalid HARNESS_TIMEOUT_SECONDS value %q: must be an integer\n", envVal)
+			os.Exit(1)
 		}
+		config.Global.TimeoutSeconds = timeout
 	}
 
 	// Add main command groups

--- a/config/globals.go
+++ b/config/globals.go
@@ -44,11 +44,8 @@ type StatusConfig struct {
 	PollInterval int
 }
 
-// DefaultTimeoutSeconds is the default request timeout
-const DefaultTimeoutSeconds = 10
-
-// MaxTimeoutSeconds is the maximum allowed request timeout
-const MaxTimeoutSeconds = 3600
+// DefaultTimeoutSeconds is the default request timeout (0 means no timeout)
+const DefaultTimeoutSeconds = 0
 
 // Global is the shared instance of GlobalFlags
 var Global = GlobalFlags{}

--- a/config/globals.go
+++ b/config/globals.go
@@ -47,5 +47,8 @@ type StatusConfig struct {
 // DefaultTimeoutSeconds is the default request timeout
 const DefaultTimeoutSeconds = 10
 
+// MaxTimeoutSeconds is the maximum allowed request timeout
+const MaxTimeoutSeconds = 3600
+
 // Global is the shared instance of GlobalFlags
 var Global = GlobalFlags{}

--- a/config/globals.go
+++ b/config/globals.go
@@ -48,6 +48,4 @@ type StatusConfig struct {
 const DefaultTimeoutSeconds = 10
 
 // Global is the shared instance of GlobalFlags
-var Global = GlobalFlags{
-	TimeoutSeconds: DefaultTimeoutSeconds,
-}
+var Global = GlobalFlags{}

--- a/config/globals.go
+++ b/config/globals.go
@@ -11,6 +11,9 @@ type GlobalFlags struct {
 	ProjectID  string
 	Format     string
 
+	// Request timeout in seconds (0 means no timeout)
+	TimeoutSeconds int
+
 	// Command-specific configurations
 	Registry RegistryConfig
 }
@@ -41,5 +44,10 @@ type StatusConfig struct {
 	PollInterval int
 }
 
+// DefaultTimeoutSeconds is the default request timeout
+const DefaultTimeoutSeconds = 10
+
 // Global is the shared instance of GlobalFlags
-var Global = GlobalFlags{}
+var Global = GlobalFlags{
+	TimeoutSeconds: DefaultTimeoutSeconds,
+}

--- a/util/client/iacm/iacm-client.go
+++ b/util/client/iacm/iacm-client.go
@@ -26,7 +26,7 @@ type IacmClient struct {
 func NewIacmClient(debug bool) *IacmClient {
 	r := resty.New()
 	r.SetBaseURL(config.Global.APIBaseURL)
-	r.SetTimeout(10 * time.Second)
+	r.SetTimeout(time.Duration(config.Global.TimeoutSeconds) * time.Second)
 	r.SetRetryCount(3)
 	r.SetRetryWaitTime(2 * time.Second)
 	r.SetRetryMaxWaitTime(60 * time.Second)


### PR DESCRIPTION
## Summary

- Adds a `--timeout` global flag (default: no timeout) to configure the HTTP request timeout for API calls
- Supports `HARNESS_TIMEOUT_SECONDS` environment variable as an alternative to the flag
- Replaces hardcoded 10-second timeout in `util/client/iacm/iacm-client.go`

## Motivation

The 10-second hardcoded timeout causes failures for API calls that legitimately take longer (e.g., large account queries, migration jobs, slow network conditions). Users currently have no way to increase this without switching to raw `curl` calls.

By defaulting to no timeout (0), long-running commands like migrations work out of the box, while users can set a timeout if desired.

## Usage

```bash
# Via flag (set 30-second timeout)
hc iacm plan --timeout 30 --org myorg --project myproject --workspace myworkspace

# Via environment variable
export HARNESS_TIMEOUT_SECONDS=30
hc iacm plan --org myorg --project myproject --workspace myworkspace

# Default behavior: no timeout
hc iacm plan --org myorg --project myproject --workspace myworkspace
```

## Changes

| File | Change |
|------|--------|
| `config/globals.go` | Added `TimeoutSeconds` field and `DefaultTimeoutSeconds` constant (default: 0) |
| `cmd/hc/main.go` | Registered `--timeout` persistent flag, `HARNESS_TIMEOUT_SECONDS` env var, and input validation |
| `util/client/iacm/iacm-client.go` | Uses configurable timeout instead of hardcoded 10s |

## Test plan

- [x] `go build ./cmd/hc/` compiles successfully
- [x] `go test ./...` — all existing tests pass
- [x] `hc --help` shows `--timeout` flag with "default: no timeout"
- [ ] Manual: `hc --timeout 30 iacm plan ...` uses 30s timeout
- [ ] Manual: `HARNESS_TIMEOUT_SECONDS=30 hc iacm plan ...` uses 30s timeout
- [ ] Manual: negative timeout value is rejected with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)