### PR TITLE
support pre-release versions

### DIFF
--- a/module/ar/packages/gopkg/impl.go
+++ b/module/ar/packages/gopkg/impl.go
@@ -46,13 +46,13 @@ func NewDefaultGenerator() *DefaultGenerator {
 type defaultModuleValidator struct{}
 
 // ValidateVersion checks if the version string follows semantic versioning format.
-// The version must be in the form vX.Y.Z where X, Y, and Z are non-negative integers.
-// For example: v1.0.0, v2.1.3
+// The version must be in the form vX.Y.Z or vX.Y.Z-prerelease where X, Y, and Z are non-negative integers.
+// For example: v1.0.0, v2.1.3, v3.24.0-rc1, v3.24.0-beta.1
 // Returns a validation error if the format is invalid.
 func (v *defaultModuleValidator) ValidateVersion(version string) error {
-	re := regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)$`)
+	re := regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)(-[a-zA-Z0-9][a-zA-Z0-9.\-]*)?$`)
 	if !re.MatchString(version) {
-		return errors.NewValidationError("version", "must be in form vX.Y.Z")
+		return errors.NewValidationError("version", "must be in form vX.Y.Z or vX.Y.Z-prerelease")
 	}
 	return nil
 }

--- a/module/ar/packages/gopkg/impl_test.go
+++ b/module/ar/packages/gopkg/impl_test.go
@@ -1,0 +1,42 @@
+package gopkg
+
+import (
+	"testing"
+)
+
+func TestValidateVersion(t *testing.T) {
+	v := &defaultModuleValidator{}
+
+	valid := []string{
+		"v1.0.0",
+		"v2.1.3",
+		"v3.22.0",
+		"v3.24.0-rc1",
+		"v3.24.0-beta.1",
+		"v3.24.0-alpha",
+		"v1.0.0-rc.2",
+		"v0.1.0-pre1",
+	}
+
+	invalid := []string{
+		"1.0.0",
+		"v1.0",
+		"v1",
+		"v1.0.0.0",
+		"v1.0.0-",
+		"latest",
+		"",
+	}
+
+	for _, ver := range valid {
+		if err := v.ValidateVersion(ver); err != nil {
+			t.Errorf("expected %q to be valid, got error: %v", ver, err)
+		}
+	}
+
+	for _, ver := range invalid {
+		if err := v.ValidateVersion(ver); err == nil {
+			t.Errorf("expected %q to be invalid, but got no error", ver)
+		}
+	}
+}

--- a/module/ar/packages/gopkg/interfaces.go
+++ b/module/ar/packages/gopkg/interfaces.go
@@ -18,7 +18,7 @@ type PackageGenerator interface {
 // and module paths according to Go module conventions.
 type ModuleValidator interface {
 	// ValidateVersion validates the package version format.
-	// The version must be in the form vX.Y.Z where X, Y, and Z are non-negative integers.
+	// The version must be in the form vX.Y.Z or vX.Y.Z-prerelease where X, Y, and Z are non-negative integers.
 	// Returns an error if the version format is invalid.
 	ValidateVersion(version string) error
 


### PR DESCRIPTION
please add support for pushing pre-release semver versions to the go artifact registry proxy. the current regex is too restrictive