### PR TITLE
Install release packages in /usr/bin

### DIFF
--- a/.goreleaser/stable.yaml
+++ b/.goreleaser/stable.yaml
@@ -64,7 +64,7 @@ nfpms:
       {{- end }}_
       {{- if eq .Arch "amd64" }}amd64
       {{- else }}{{ .Arch }}{{ end }}
-    bindir: /usr/local/bin
+    bindir: /usr/bin
 
 checksum:
   name_template: "checksums.txt"
@@ -135,4 +135,3 @@ changelog:
       - '^chore:'
       - Merge pull request
       - Merge branch
-


### PR DESCRIPTION
## Summary

Set `nfpms.bindir` in `.goreleaser/stable.yaml` to `/usr/bin`. GoReleaser uses this setting for its Debian and RPM packages.

[Debian Policy §9.1.2](https://www.debian.org/doc/debian-policy/ch-opersys.html#site-specific-programs) reserves `/usr/local` for site-specific software installed by the local administrator. The [Fedora Packaging Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/) prohibit distribution packages from placing files there.

Debian's lintian reports `linux-binary-under-usr-local` for binaries installed under `/usr/local`. Installing `hc` in `/usr/bin` avoids that condition for packages generated from this configuration.

## Verification

- Parsed `.goreleaser/stable.yaml` with Ruby's YAML parser.
- Ran `git diff --check`.
- Did not run `goreleaser check --config .goreleaser/stable.yaml`: `goreleaser` is not installed.
- Did not build a release package or run lintian. Other Debian package findings are unknown.
